### PR TITLE
Removed global variable usage to fix new holiday creation

### DIFF
--- a/custom_components/calendarific/__init__.py
+++ b/custom_components/calendarific/__init__.py
@@ -37,7 +37,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 _LOGGER = logging.getLogger(__name__)
 
-holiday_list = []
 
 def setup(hass, config):
     """Set up platform using YAML."""
@@ -97,6 +96,9 @@ class CalendarificApiReader:
         except:
             return "NOT FOUND"
 
+    def get_holidays(self):
+        return [item['name'] for item in self._holidays]
+
     def update(self):
         if self._lastupdated == datetime.now().date():
             return
@@ -121,10 +123,6 @@ class CalendarificApiReader:
             return
         self._error_logged = False
         self._next_holidays = response['response']['holidays']
-        global holiday_list
-        holiday_list = []
-        for holiday in self._holidays:
-            holiday_list.append(holiday['name'])
         
         return True
 

--- a/custom_components/calendarific/__init__.py
+++ b/custom_components/calendarific/__init__.py
@@ -7,7 +7,8 @@ import requests
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 
 from homeassistant import config_entries
 import homeassistant.helpers.config_validation as cv
@@ -52,15 +53,13 @@ def setup(hass, config):
     return True
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "sensor")
-    )
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])
     return True
 
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
-    return await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+    return await hass.config_entries.async_forward_entry_unload(entry, Platform.SENSOR)
 
 class CalendarificApiReader:
 

--- a/custom_components/calendarific/config_flow.py
+++ b/custom_components/calendarific/config_flow.py
@@ -5,6 +5,7 @@ import uuid
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant import core
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 
@@ -27,7 +28,6 @@ from .const import (
     CONF_UNIT_OF_MEASUREMENT,
 )
 
-from . import holiday_list
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,9 +46,11 @@ class CalendarificConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._errors = {}
         self._data = {}
         self._data["unique_id"] = str(uuid.uuid4())
+        hass = core.async_get_hass()
+        self._holiday_list = hass.data[DOMAIN]["apiReader"].get_holidays()
 
     async def async_step_user(self, user_input=None):
-        if holiday_list == []:
+        if self._holiday_list == []:
             return self.async_abort(reason="no_holidays_found")
         self._errors = {}
         if user_input is not None:
@@ -84,7 +86,7 @@ class CalendarificConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if CONF_UNIT_OF_MEASUREMENT in user_input:
                 unit_of_measurement = user_input[CONF_UNIT_OF_MEASUREMENT]
         data_schema = OrderedDict()
-        data_schema[vol.Required(CONF_HOLIDAY, default=holiday)] = vol.In(holiday_list) 
+        data_schema[vol.Required(CONF_HOLIDAY, default=holiday)] = vol.In(self._holiday_list) 
         data_schema[vol.Optional(CONF_NAME, default=name)] = str
         data_schema[vol.Required(CONF_UNIT_OF_MEASUREMENT, default=unit_of_measurement)] = str
         data_schema[vol.Required(CONF_ICON_NORMAL, default=icon_normal)] = str


### PR DESCRIPTION
I'm not sure if a recent python version changed the way global variables worked, and I'm not entirely sure what version of HA broke this, but I can no longer create holidays. This PR resolves #43 